### PR TITLE
Use preferred DOI resolver

### DIFF
--- a/DHJMFCrawler/src/main/java/de/dhjmf/BibsonomyService.java
+++ b/DHJMFCrawler/src/main/java/de/dhjmf/BibsonomyService.java
@@ -77,10 +77,10 @@ public class BibsonomyService {
         	/* call the Bibsonomy scraper */
         	try {
         		String url = "";
-        		if (line.contains("dx.doi")) {
+        		if (line.contains("doi.org")) {
 	        		URL urlobj = new URL(line);
 	        		URLConnection conn = urlobj.openConnection();
-        			url = conn.getHeaderField("Link").split(";")[0].replace("<", "").replace(">", ""); // get original URL if dx.doi.org was used
+        			url = conn.getHeaderField("Link").split(";")[0].replace("<", "").replace(">", ""); // get original URL if doi.org was used
         			System.out.println("Verwendete (Original-)URL: " + url);
         		} else {
         			url = line;  // use URL from file in all other cases

--- a/DHJMFCrawler/src/main/java/de/dhjmf/scraper/ZfdGScraper.java
+++ b/DHJMFCrawler/src/main/java/de/dhjmf/scraper/ZfdGScraper.java
@@ -96,7 +96,7 @@ public class ZfdGScraper extends AbstractUrlScraper {
 	private static final Pattern PATTERN_TEI_XML = Pattern.compile("<div id=\"xml_but\" class=\"but\"><a href=\"([^\"]*)\"");
 	private static final Pattern PATTERN_KEY_VALUE = Pattern.compile("([^=]*)=(([^&]|&(?!amp;))*)(&amp;|&)?");
 	private static final Pattern PATTERN_DATE = Pattern.compile("(\\d{4})");
-	private static final Pattern PATTERN_DOI = Pattern.compile("http://dx.doi.org/(.*)");
+	private static final Pattern PATTERN_DOI = Pattern.compile("https?://(dx\.)?doi.org/(.*)");
 	private static final Pattern PATTERN_ABSTRACT = Pattern.compile("<h1>Abstract</h1>(([^<]|<(?!/p>))*)</p>", Pattern.DOTALL);
 	// TODO: weitere Abstracts berücksichtigen ("<div id=\"abstract_de\" class=\"abstract\"><h1>Abstract</h1>(([^<]|<(?!/p>))*)</p>" funktioniert nicht...)
 

--- a/DHJMFCrawler/src/main/resources/config.properties.default
+++ b/DHJMFCrawler/src/main/resources/config.properties.default
@@ -32,7 +32,7 @@ dhjmf.mail.subject = <SUBJECT OF SENT MAIL>
 dhjmf.mail.body = <BODY/TEXT IN SENT MAIL>
 ## general
 dhjmf.common.workdir = <WORKING DIRECTORY, e.g. /home/USERNAME/crawlingservice/>
-dhjmf.common.doiURL = http://dx.doi.org/
+dhjmf.common.doiURL = https://doi.org/
 # Name of the directory for new links
 dhjmf.common.folder.newlinks = newlinks
 # Namespaces to be removed from RSS feeds


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all code that ether generates DOI links, or checks inputs for them.

Cheers!